### PR TITLE
fix: return wrong path

### DIFF
--- a/PCodeMallocDemo/MallocTrace.java
+++ b/PCodeMallocDemo/MallocTrace.java
@@ -282,7 +282,7 @@ public class MallocTrace extends GhidraScript {
 			
 		}
 		
-		return currentPath;
+		return path;
 	}
 
 


### PR DESCRIPTION
I think here should return `path` instead of `currentPath`, since `path` has already appended `currentPath` as its parent. And at the end of recursion, we need `path` instead of a subpath.

```
    //dispatch to analysis of the particular function callsite we are examining to determine how the parameter is defined
    currentPath = analyzeFunctionCallSite(parentNode, getFunctionContaining(currentReference.getFromAddress()), currentOp, paramSlot);

    path.appendNewParent(currentPath);
```

This bug occurred when I tried to analyze mips and arm versions of MallocExample with this script. Although there is no such problem in x86 results, this bug should be fixed.